### PR TITLE
Monkey patch active resource. Make the methods allowed to pass headers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Don't put *.swp, *.bak, etc here; those belong in a global ~/.gitignore.
 # Check out http://help.github.com/ignore-files/ for how to set that up.
 
+.idea
 debug.log
 .Gemfile
 /.bundle

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "activeresource"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install

--- a/lib/active_resource/custom_methods.rb
+++ b/lib/active_resource/custom_methods.rb
@@ -55,28 +55,28 @@ module ActiveResource
         # <tt>:from</tt> option. For example:
         #
         #   Person.find(:all, :from => :active)
-        def get(custom_method_name, options = {})
-          hashified = format.decode(connection.get(custom_method_collection_url(custom_method_name, options), headers).body)
+        def get(custom_method_name, options = {}, instance_headers = {})
+          hashified = format.decode(connection.get(custom_method_collection_url(custom_method_name, options), custom_headers(instance_headers)).body)
           derooted  = Formats.remove_root(hashified)
           derooted.is_a?(Array) ? derooted.map { |e| Formats.remove_root(e) } : derooted
         end
 
-        def post(custom_method_name, options = {}, body = "")
-          connection.post(custom_method_collection_url(custom_method_name, options), body, headers)
+        def post(custom_method_name, options = {}, body = "", instance_headers = {})
+          connection.post(custom_method_collection_url(custom_method_name, options), body, custom_headers(instance_headers))
         end
 
-        def patch(custom_method_name, options = {}, body = "")
-          connection.patch(custom_method_collection_url(custom_method_name, options), body, headers)
+        def patch(custom_method_name, options = {}, body = "", instance_headers = {})
+          connection.patch(custom_method_collection_url(custom_method_name, options), body, custom_headers(instance_headers))
         end
 
-        def put(custom_method_name, options = {}, body = "")
-          connection.put(custom_method_collection_url(custom_method_name, options), body, headers)
+        def put(custom_method_name, options = {}, body = "", instance_headers = {})
+          connection.put(custom_method_collection_url(custom_method_name, options), body, custom_headers(instance_headers))
         end
 
-        def delete(custom_method_name, options = {})
+        def delete(custom_method_name, options = {}, instance_headers = {})
           # Need to jump through some hoops to retain the original class 'delete' method
           if custom_method_name.is_a?(Symbol)
-            connection.delete(custom_method_collection_url(custom_method_name, options), headers)
+            connection.delete(custom_method_collection_url(custom_method_name, options), custom_headers(instance_headers))
           else
             orig_delete(custom_method_name, options)
           end
@@ -91,29 +91,29 @@ module ActiveResource
       end
     end
 
-    def get(method_name, options = {})
-      self.class.format.decode(connection.get(custom_method_element_url(method_name, options), self.class.headers).body)
+    def get(method_name, options = {}, instance_headers = {})
+      self.class.format.decode(connection.get(custom_method_element_url(method_name, options), self.class.custom_headers(instance_headers)).body)
     end
 
-    def post(method_name, options = {}, body = nil)
+    def post(method_name, options = {}, body = nil, instance_headers = {})
       request_body = body.blank? ? encode : body
       if new?
-        connection.post(custom_method_new_element_url(method_name, options), request_body, self.class.headers)
+        connection.post(custom_method_new_element_url(method_name, options), request_body, self.class.custom_headers(instance_headers))
       else
-        connection.post(custom_method_element_url(method_name, options), request_body, self.class.headers)
+        connection.post(custom_method_element_url(method_name, options), request_body, self.class.custom_headers(instance_headers))
       end
     end
 
-    def patch(method_name, options = {}, body = "")
-      connection.patch(custom_method_element_url(method_name, options), body, self.class.headers)
+    def patch(method_name, options = {}, body = "", instance_headers = {})
+      connection.patch(custom_method_element_url(method_name, options), body, self.class.custom_headers(instance_headers))
     end
 
-    def put(method_name, options = {}, body = "")
-      connection.put(custom_method_element_url(method_name, options), body, self.class.headers)
+    def put(method_name, options = {}, body = "", instance_headers = {})
+      connection.put(custom_method_element_url(method_name, options), body, self.class.custom_headers(instance_headers))
     end
 
-    def delete(method_name, options = {})
-      connection.delete(custom_method_element_url(method_name, options), self.class.headers)
+    def delete(method_name, options = {}, instance_headers = {})
+      connection.delete(custom_method_element_url(method_name, options), self.class.custom_headers(instance_headers))
     end
 
 


### PR DESCRIPTION
We found out that active resource not a thread safe headers. The only option for headers on active resource is at class variable. It could be make an issue when several users with different token (stored on headers) access the application (implemented active resource) in a same time. For example, when user A access lead detail page, then user B access some other page. Then user A make an update on the lead, the token has been replaced by user B and it make user A got an error unathorized!

This patch make assign headers on method level. It should be thread safe. For the consequence, we should add instance headers argument on each methods. If you want to implement this patch, you should add that argument. Fortunately, the additional argument has default value, it should'nt be make a problem for user who want to just implement base active resource. Still, I encourage all implementation in our rails application implement this patch!